### PR TITLE
Added test helper library with expectation type

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,13 +37,20 @@ let package = Package(
             name: "TypedNotification",
             type: .dynamic,
             targets: ["TypedNotification"]),
+        .library(
+            name: "TypedNotificationTestHelpers",
+            type: .dynamic,
+            targets: ["TypedNotificationTestHelpers"])
     ],
     targets: [
         .target(
             name: "TypedNotification",
             dependencies: []),
+        .target(
+            name: "TypedNotificationTestHelpers",
+            dependencies: ["TypedNotification"]),
         .testTarget(
             name: "TypedNotificationTests",
-            dependencies: ["TypedNotification"])
+            dependencies: ["TypedNotification", "TypedNotificationTestHelpers"])
     ]
 )

--- a/Sources/TypedNotification/TypedNotification.swift
+++ b/Sources/TypedNotification/TypedNotification.swift
@@ -54,6 +54,13 @@ extension TypedNotification {
     func notification(withSender sender: Any) -> Notification {
         return Notification(name: Self.notificationName, object: sender, userInfo: [kNotificationKey: self])
     }
+
+    public static func unpack(from notification: Notification) -> Self? {
+        guard let typedNotification = notification.userInfo?[kNotificationKey] as? Self else {
+            return nil
+        }
+        return typedNotification
+    }
 }
 
 /// An opaque `NotificationToken` used to add and remove observers of typed notifications. The object retains the token returned by `NotificationCenter.addObserver(for:object:queue:)` as well as the `NotificationCenter`. When the object is deallocated, we deregister the observer from the retained `NotificationCenter` using the retained token.
@@ -137,7 +144,7 @@ extension NotificationCenter {
                                                   using block: @escaping (T) -> Void) -> NotificationToken {
 
         let token = addObserver(forName: T.notificationName, object: object, queue: queue) { (notification) in
-            guard let typedNotification = notification.userInfo?[kNotificationKey] as? T else {
+            guard let typedNotification = T.unpack(from: notification) else {
                 return
             }
 

--- a/Sources/TypedNotificationTestHelpers/TypedNotificationExpectation.swift
+++ b/Sources/TypedNotificationTestHelpers/TypedNotificationExpectation.swift
@@ -1,0 +1,62 @@
+//
+//  TypedNotificationExpectation.swift
+//  TypedNotificationTestHelpers
+//
+//  Copyright (c) 2021 Rocket Insights, Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//  DEALINGS IN THE SOFTWARE.
+//
+
+import TypedNotification
+import XCTest
+
+/**
+ Adapts XCTNSNotificationExpectation to be fulfilled when a particular TypedNotification is received. Adds a `typedHandler` property that handles unpackaging the notification into the appropriate subtype.
+ */
+public class TypedNotificationExpectation<T: TypedNotification>: XCTNSNotificationExpectation {
+
+    public typealias Handler = (T) -> Bool
+
+    /**
+     Creates an expectation that is fulfilled when a TypedNotification of the specified type is posted to the specified notification center.
+
+     - Parameters:
+        - for type: the `TypedNotification` subtype
+        - object: The object from which you want to receive notifications. Pass `nil` to receive all notifications.
+        - notificationCenter: The notification center from which the notification must be posted.
+     */
+    public init(for type: T.Type, object: Any? = nil, notificationCenter: NotificationCenter = .default) {
+        super.init(name: T.notificationName, object: object, notificationCenter: notificationCenter)
+    }
+
+    /**
+     An optional handler that performs custom evaluation of matching notifications. Your implementation should return `true` if the expectation is considered fulfilled after the notification is received, otherwise false.
+     */
+    public var typedHandler: Handler? {
+        didSet {
+            handler = { [weak self] (notification) -> Bool in
+                guard let unpacked = T.unpack(from: notification) else {
+                    return false
+                }
+
+                return self?.typedHandler?(unpacked) ?? true
+            }
+        }
+    }
+}

--- a/Tests/TypedNotificationTests/TypedNotificationTests.swift
+++ b/Tests/TypedNotificationTests/TypedNotificationTests.swift
@@ -24,6 +24,7 @@
 //
 
 import TypedNotification
+import TypedNotificationTestHelpers
 import XCTest
 
 class TypedNotificationTests: XCTestCase {
@@ -42,11 +43,10 @@ class TypedNotificationTests: XCTestCase {
     }
 
     func testBehavior() {
-        let exp = expectation(description: "notification received")
-
-        token = NotificationCenter.default.addObserver(for: TestNotification.self, queue: .main) { notification in
-            XCTAssertEqual(notification.value, "foobar")
-            exp.fulfill()
+        let exp = TypedNotificationExpectation(for: TestNotification.self)
+        exp.typedHandler = {
+            XCTAssertEqual($0.value, "foobar")
+            return true
         }
 
         DispatchQueue.global(qos: .background).async {


### PR DESCRIPTION
Added `TypedNotificationExpectation` in the new `TypedNotificationTestHelpers` library. Adapts `XCTNSNotificationExpectation` to operate seamlessly with a `TypedNotification`.

Also adds a static `unpack` function on the `TypedNotification` default implementation extension.